### PR TITLE
feat: 도시 검색 및 추가 화면 UI 구성

### DIFF
--- a/app/src/main/assets/cities.json
+++ b/app/src/main/assets/cities.json
@@ -1,0 +1,2092 @@
+[
+    {
+        "id": 1832008,
+        "name": "Tokusan-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.699997,
+            "lat": 35.133331
+        },
+        "name_ko": "덕산리"
+    },
+    {
+        "id": 1832015,
+        "name": "Heunghae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.352219,
+            "lat": 36.112499
+        },
+        "name_ko": "흥해"
+    },
+    {
+        "id": 1832157,
+        "name": "Reisui",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.737778,
+            "lat": 34.744171
+        },
+        "name_ko": "여수"
+    },
+    {
+        "id": 1832215,
+        "name": "Yeonil",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.345001,
+            "lat": 35.994171
+        },
+        "name_ko": "연일"
+    },
+    {
+        "id": 1832257,
+        "name": "Neietsu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.468216,
+            "lat": 37.184471
+        },
+        "name_ko": "영월"
+    },
+    {
+        "id": 1832384,
+        "name": "Eisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.630829,
+            "lat": 36.821671
+        },
+        "name_ko": "영주"
+    },
+    {
+        "id": 1832427,
+        "name": "Yongin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.20639,
+            "lat": 37.234169
+        },
+        "name_ko": "용인"
+    },
+    {
+        "id": 1832501,
+        "name": "Yeonggwang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.509438,
+            "lat": 35.275002
+        },
+        "name_ko": "영광"
+    },
+    {
+        "id": 1832566,
+        "name": "Yeongdong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.77639,
+            "lat": 36.174999
+        },
+        "name_ko": "영동"
+    },
+    {
+        "id": 1832663,
+        "name": "Yeongam-guncheong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.699997,
+            "lat": 34.798328
+        },
+        "name_ko": "영암군청"
+    },
+    {
+        "id": 1832697,
+        "name": "Yeoncheon-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.075768,
+            "lat": 38.09404
+        },
+        "name_ko": "연천군"
+    },
+    {
+        "id": 1832743,
+        "name": "Yeoju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.633888,
+            "lat": 37.29583
+        },
+        "name_ko": "여주"
+    },
+    {
+        "id": 1832771,
+        "name": "Yesan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.84272,
+            "lat": 36.677559
+        },
+        "name_ko": "예산"
+    },
+    {
+        "id": 1832798,
+        "name": "Yecheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.45694,
+            "lat": 36.65556
+        },
+        "name_ko": "예천"
+    },
+    {
+        "id": 1832809,
+        "name": "Yangyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.621109,
+            "lat": 38.073891
+        },
+        "name_ko": "양양"
+    },
+    {
+        "id": 1832828,
+        "name": "Yangsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.038605,
+            "lat": 35.338612
+        },
+        "name_ko": "양산"
+    },
+    {
+        "id": 1832830,
+        "name": "Yangp'yŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.490562,
+            "lat": 37.489719
+        },
+        "name_ko": "양평"
+    },
+    {
+        "id": 1832847,
+        "name": "Yangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.061691,
+            "lat": 37.833111
+        },
+        "name_ko": "양주"
+    },
+    {
+        "id": 1832909,
+        "name": "Yanggu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.989441,
+            "lat": 38.105831
+        },
+        "name_ko": "양구"
+    },
+    {
+        "id": 1832973,
+        "name": "Yach’on",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.815826,
+            "lat": 35.13028
+        },
+        "name_ko": "야촌"
+    },
+    {
+        "id": 1833105,
+        "name": "Wŏnju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.945282,
+            "lat": 37.351391
+        },
+        "name_ko": "원주"
+    },
+    {
+        "id": 1833466,
+        "name": "Wanju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.147522,
+            "lat": 35.845089
+        },
+        "name_ko": "완주"
+    },
+    {
+        "id": 1833514,
+        "name": "Waegwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.397324,
+            "lat": 35.991749
+        },
+        "name_ko": "왜관"
+    },
+    {
+        "id": 1833581,
+        "name": "Unsal-li",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.20472,
+            "lat": 38.054169
+        },
+        "name_ko": "운산리"
+    },
+    {
+        "id": 1833702,
+        "name": "Umulmok",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.316673,
+            "lat": 38.049999
+        },
+        "name_ko": "우물목"
+    },
+    {
+        "id": 1833742,
+        "name": "Ulsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.266663,
+            "lat": 35.566669
+        },
+        "name_ko": "울산"
+    },
+    {
+        "id": 1833763,
+        "name": "Ulchin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.399994,
+            "lat": 36.992939
+        },
+        "name_ko": "울진"
+    },
+    {
+        "id": 1833788,
+        "name": "Uijeongbu-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.047401,
+            "lat": 37.741501
+        },
+        "name_ko": "의정부시"
+    },
+    {
+        "id": 1834885,
+        "name": "Tangjin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.629723,
+            "lat": 36.89444
+        },
+        "name_ko": "당진"
+    },
+    {
+        "id": 1835096,
+        "name": "Taesal-li",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.454201,
+            "lat": 36.971401
+        },
+        "name_ko": "태산리"
+    },
+    {
+        "id": 1835224,
+        "name": "Daejeon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.416672,
+            "lat": 36.333328
+        },
+        "name_ko": "대전"
+    },
+    {
+        "id": 1835327,
+        "name": "Daegu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.550003,
+            "lat": 35.799999
+        },
+        "name_ko": "대구"
+    },
+    {
+        "id": 1835447,
+        "name": "Boryeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.597717,
+            "lat": 36.349312
+        },
+        "name_ko": "보령"
+    },
+    {
+        "id": 1835515,
+        "name": "T’aebaek",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.988907,
+            "lat": 37.1759
+        },
+        "name_ko": "태백"
+    },
+    {
+        "id": 1835518,
+        "name": "Taian",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.297783,
+            "lat": 36.75639
+        },
+        "name_ko": "태안"
+    },
+    {
+        "id": 1835553,
+        "name": "Suwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.008888,
+            "lat": 37.291111
+        },
+        "name_ko": "수원"
+    },
+    {
+        "id": 1835648,
+        "name": "Suncheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.489471,
+            "lat": 34.948078
+        },
+        "name_ko": "순천"
+    },
+    {
+        "id": 1835650,
+        "name": "Sunchang-chodeunghakgyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.142776,
+            "lat": 35.373611
+        },
+        "name_ko": "순창초등학교"
+    },
+    {
+        "id": 1835841,
+        "name": "Republic of Korea",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.5,
+            "lat": 37.0
+        },
+        "name_ko": "대한민국"
+    },
+    {
+        "id": 1835847,
+        "name": "Seoul",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.583328
+        },
+        "name_ko": "서울"
+    },
+    {
+        "id": 1835895,
+        "name": "Seosan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.452217,
+            "lat": 36.78167
+        },
+        "name_ko": "서산"
+    },
+    {
+        "id": 1835967,
+        "name": "Jenzan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.297501,
+            "lat": 36.240829
+        },
+        "name_ko": "선주"
+    },
+    {
+        "id": 1836034,
+        "name": "Seisan-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.066666,
+            "lat": 35.099998
+        },
+        "name_ko": "세이산리"
+    },
+    {
+        "id": 1836164,
+        "name": "Songjeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.357224,
+            "lat": 35.589169
+        },
+        "name_ko": "송정"
+    },
+    {
+        "id": 1836208,
+        "name": "Seonghwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.131393,
+            "lat": 36.915562
+        },
+        "name_ko": "성환"
+    },
+    {
+        "id": 1836553,
+        "name": "Sokcho",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.59111,
+            "lat": 38.208328
+        },
+        "name_ko": "속초"
+    },
+    {
+        "id": 1837055,
+        "name": "Yongsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.966667,
+            "lat": 37.533329
+        },
+        "name_ko": "용산"
+    },
+    {
+        "id": 1837217,
+        "name": "Sinch’ŏn-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.083328,
+            "lat": 37.51667
+        },
+        "name_ko": "신촌동"
+    },
+    {
+        "id": 1837640,
+        "name": "Sangok",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.616669,
+            "lat": 34.833328
+        },
+        "name_ko": "상옥"
+    },
+    {
+        "id": 1837660,
+        "name": "Sang-ni",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.106201,
+            "lat": 36.251099
+        },
+        "name_ko": "상리"
+    },
+    {
+        "id": 1837706,
+        "name": "Sangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.160553,
+            "lat": 36.415279
+        },
+        "name_ko": "상주"
+    },
+    {
+        "id": 1838069,
+        "name": "Santyoku",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.170837,
+            "lat": 37.440559
+        },
+        "name_ko": "삼척"
+    },
+    {
+        "id": 1838294,
+        "name": "Shisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.088608,
+            "lat": 35.084171
+        },
+        "name_ko": "사천"
+    },
+    {
+        "id": 1838343,
+        "name": "Pyeongtaek",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.08889,
+            "lat": 36.99472
+        },
+        "name_ko": "평택"
+    },
+    {
+        "id": 1838431,
+        "name": "Pyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.0
+        },
+        "name_ko": "평"
+    },
+    {
+        "id": 1838508,
+        "name": "Buyeo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.912498,
+            "lat": 36.28194
+        },
+        "name_ko": "부여"
+    },
+    {
+        "id": 1838519,
+        "name": "Busan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.050003,
+            "lat": 35.133331
+        },
+        "name_ko": "부산"
+    },
+    {
+        "id": 1838716,
+        "name": "Bucheon-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.783058,
+            "lat": 37.49889
+        },
+        "name_ko": "부천시"
+    },
+    {
+        "id": 1838722,
+        "name": "Puan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.731941,
+            "lat": 35.728062
+        },
+        "name_ko": "부안"
+    },
+    {
+        "id": 1838740,
+        "name": "Boseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.080887,
+            "lat": 34.769718
+        },
+        "name_ko": "보성"
+    },
+    {
+        "id": 1839011,
+        "name": "Beolgyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.342934,
+            "lat": 34.84494
+        },
+        "name_ko": "벌교"
+    },
+    {
+        "id": 1839071,
+        "name": "Pohang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.365005,
+            "lat": 36.032219
+        },
+        "name_ko": "포항"
+    },
+    {
+        "id": 1839652,
+        "name": "Osan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.070557,
+            "lat": 37.152222
+        },
+        "name_ko": "오산"
+    },
+    {
+        "id": 1839726,
+        "name": "Asan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.004173,
+            "lat": 36.783611
+        },
+        "name_ko": "아산"
+    },
+    {
+        "id": 1839873,
+        "name": "Okcheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.568001,
+            "lat": 36.301201
+        },
+        "name_ko": "옥천"
+    },
+    {
+        "id": 1840179,
+        "name": "Kosong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.467606,
+            "lat": 38.378811
+        },
+        "name_ko": "고성"
+    },
+    {
+        "id": 1840211,
+        "name": "Nonsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.084717,
+            "lat": 36.203892
+        },
+        "name_ko": "논산"
+    },
+    {
+        "id": 1840377,
+        "name": "Namyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.816673,
+            "lat": 37.208889
+        },
+        "name_ko": "남양"
+    },
+    {
+        "id": 1840379,
+        "name": "Nangen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.385834,
+            "lat": 35.41
+        },
+        "name_ko": "낭엔"
+    },
+    {
+        "id": 1840421,
+        "name": "Namp’o-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.790833,
+            "lat": 35.811939
+        },
+        "name_ko": "남포리"
+    },
+    {
+        "id": 1840454,
+        "name": "Namhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.89444,
+            "lat": 34.839439
+        },
+        "name_ko": "남해"
+    },
+    {
+        "id": 1840536,
+        "name": "Naju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.717499,
+            "lat": 35.028332
+        },
+        "name_ko": "나주"
+    },
+    {
+        "id": 1840862,
+        "name": "Munsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.785004,
+            "lat": 37.85944
+        },
+        "name_ko": "문산"
+    },
+    {
+        "id": 1840886,
+        "name": "Mungyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.199463,
+            "lat": 36.594582
+        },
+        "name_ko": "문경"
+    },
+    {
+        "id": 1840898,
+        "name": "Paju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.775002,
+            "lat": 37.761108
+        },
+        "name_ko": "파주"
+    },
+    {
+        "id": 1840942,
+        "name": "Muju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.661392,
+            "lat": 36.007221
+        },
+        "name_ko": "무주"
+    },
+    {
+        "id": 1840982,
+        "name": "Muan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.47139,
+            "lat": 34.989719
+        },
+        "name_ko": "무안"
+    },
+    {
+        "id": 1841066,
+        "name": "Mokpo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.388611,
+            "lat": 34.79361
+        },
+        "name_ko": "목포"
+    },
+    {
+        "id": 1841149,
+        "name": "Miryang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.748886,
+            "lat": 35.493328
+        },
+        "name_ko": "밀양"
+    },
+    {
+        "id": 1841245,
+        "name": "Masan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.572495,
+            "lat": 35.208061
+        },
+        "name_ko": "마산"
+    },
+    {
+        "id": 1841597,
+        "name": "Gyeongsangbuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.75,
+            "lat": 36.333328
+        },
+        "name_ko": "경상북도"
+    },
+    {
+        "id": 1841598,
+        "name": "Gyeongsan-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.737778,
+            "lat": 35.82333
+        },
+        "name_ko": "경산시"
+    },
+    {
+        "id": 1841603,
+        "name": "Gyeongju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.21167,
+            "lat": 35.842781
+        },
+        "name_ko": "경주"
+    },
+    {
+        "id": 1841610,
+        "name": "Gyeonggi-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.25,
+            "lat": 37.599998
+        },
+        "name_ko": "경기도"
+    },
+    {
+        "id": 1841775,
+        "name": "Kwangyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.589172,
+            "lat": 34.975281
+        },
+        "name_ko": "광양"
+    },
+    {
+        "id": 1841808,
+        "name": "Gwangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.916672,
+            "lat": 35.166672
+        },
+        "name_ko": "광주"
+    },
+    {
+        "id": 1841909,
+        "name": "Gwacheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.989166,
+            "lat": 37.42889
+        },
+        "name_ko": "과천"
+    },
+    {
+        "id": 1841919,
+        "name": "Kuwaegwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.394608,
+            "lat": 36.015099
+        },
+        "name_ko": "구왜관"
+    },
+    {
+        "id": 1841976,
+        "name": "Kurye",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.464439,
+            "lat": 35.209438
+        },
+        "name_ko": "구례"
+    },
+    {
+        "id": 1841988,
+        "name": "Guri-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.139397,
+            "lat": 37.598598
+        },
+        "name_ko": "구리시"
+    },
+    {
+        "id": 1842016,
+        "name": "Kunwi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.572784,
+            "lat": 36.234718
+        },
+        "name_ko": "군위"
+    },
+    {
+        "id": 1842025,
+        "name": "Gunsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.711388,
+            "lat": 35.978611
+        },
+        "name_ko": "군산"
+    },
+    {
+        "id": 1842030,
+        "name": "Gunpo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.946938,
+            "lat": 37.3675
+        },
+        "name_ko": "군포"
+    },
+    {
+        "id": 1842153,
+        "name": "Kinzan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.488892,
+            "lat": 36.103062
+        },
+        "name_ko": "금산"
+    },
+    {
+        "id": 1842225,
+        "name": "Gumi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.335999,
+            "lat": 36.113602
+        },
+        "name_ko": "구미"
+    },
+    {
+        "id": 1842485,
+        "name": "Goyang-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.834999,
+            "lat": 37.656391
+        },
+        "name_ko": "고양시"
+    },
+    {
+        "id": 1842518,
+        "name": "Goseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.323608,
+            "lat": 34.976311
+        },
+        "name_ko": "고성"
+    },
+    {
+        "id": 1842559,
+        "name": "Koryŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.267548,
+            "lat": 35.729389
+        },
+        "name_ko": "고령"
+    },
+    {
+        "id": 1842616,
+        "name": "Gongju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.124718,
+            "lat": 36.455559
+        },
+        "name_ko": "공주"
+    },
+    {
+        "id": 1842754,
+        "name": "Kyosai",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.588608,
+            "lat": 34.850281
+        },
+        "name_ko": "거제"
+    },
+    {
+        "id": 1842781,
+        "name": "Koyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.284462,
+            "lat": 34.610081
+        },
+        "name_ko": "고흥"
+    },
+    {
+        "id": 1842800,
+        "name": "Koesan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.794724,
+            "lat": 36.810829
+        },
+        "name_ko": "괴산"
+    },
+    {
+        "id": 1842859,
+        "name": "Koch'ang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.699997,
+            "lat": 35.433331
+        },
+        "name_ko": "고창"
+    },
+    {
+        "id": 1842936,
+        "name": "Gimpo-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.714172,
+            "lat": 37.623611
+        },
+        "name_ko": "김포시"
+    },
+    {
+        "id": 1842939,
+        "name": "Kimje",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.888893,
+            "lat": 35.80167
+        },
+        "name_ko": "김제"
+    },
+    {
+        "id": 1842943,
+        "name": "Kimhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.881104,
+            "lat": 35.234169
+        },
+        "name_ko": "김해"
+    },
+    {
+        "id": 1842944,
+        "name": "Gimcheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.119812,
+            "lat": 36.121761
+        },
+        "name_ko": "김천"
+    },
+    {
+        "id": 1842966,
+        "name": "Gijang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.213882,
+            "lat": 35.244171
+        },
+        "name_ko": "기장"
+    },
+    {
+        "id": 1843082,
+        "name": "Gapyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.51059,
+            "lat": 37.831009
+        },
+        "name_ko": "가평"
+    },
+    {
+        "id": 1843125,
+        "name": "Gangwon-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.25,
+            "lat": 37.75
+        },
+        "name_ko": "강원도"
+    },
+    {
+        "id": 1843137,
+        "name": "Gangneung",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.896103,
+            "lat": 37.755562
+        },
+        "name_ko": "강릉"
+    },
+    {
+        "id": 1843163,
+        "name": "Ganghwa-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.485558,
+            "lat": 37.747219
+        },
+        "name_ko": "강화군"
+    },
+    {
+        "id": 1843491,
+        "name": "Iksan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.954437,
+            "lat": 35.94389
+        },
+        "name_ko": "익산"
+    },
+    {
+        "id": 1843495,
+        "name": "Ipyang-ni",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.5,
+            "lat": 36.716671
+        },
+        "name_ko": "이평리"
+    },
+    {
+        "id": 1843502,
+        "name": "Ipseokdong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.649994,
+            "lat": 35.900002
+        },
+        "name_ko": "입석동"
+    },
+    {
+        "id": 1843542,
+        "name": "Inje",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.173065,
+            "lat": 38.065559
+        },
+        "name_ko": "인제"
+    },
+    {
+        "id": 1843561,
+        "name": "Incheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.416107,
+            "lat": 37.450001
+        },
+        "name_ko": "인천"
+    },
+    {
+        "id": 1843585,
+        "name": "Imsil",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.279442,
+            "lat": 35.61306
+        },
+        "name_ko": "임실"
+    },
+    {
+        "id": 1843702,
+        "name": "Icheon-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.442497,
+            "lat": 37.279171
+        },
+        "name_ko": "이천시"
+    },
+    {
+        "id": 1843841,
+        "name": "Hwasun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.985001,
+            "lat": 35.059441
+        },
+        "name_ko": "화순"
+    },
+    {
+        "id": 1843847,
+        "name": "Hwaseong-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.816902,
+            "lat": 37.206821
+        },
+        "name_ko": "화성시"
+    },
+    {
+        "id": 1843880,
+        "name": "Hwapyeongri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.569901,
+            "lat": 37.24754
+        },
+        "name_ko": "화평리"
+    },
+    {
+        "id": 1844045,
+        "name": "Hwacheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.706673,
+            "lat": 38.10611
+        },
+        "name_ko": "화천"
+    },
+    {
+        "id": 1844088,
+        "name": "Hŭngjŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.416672,
+            "lat": 36.333328
+        },
+        "name_ko": "흥전"
+    },
+    {
+        "id": 1844106,
+        "name": "Kulgwan-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.553062,
+            "lat": 37.209721
+        },
+        "name_ko": "굴관동"
+    },
+    {
+        "id": 1844174,
+        "name": "Hongseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.665001,
+            "lat": 36.600899
+        },
+        "name_ko": "홍성"
+    },
+    {
+        "id": 1844191,
+        "name": "Hongch’ŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.885696,
+            "lat": 37.691799
+        },
+        "name_ko": "홍천"
+    },
+    {
+        "id": 1844308,
+        "name": "Hayang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.820007,
+            "lat": 35.91333
+        },
+        "name_ko": "하양"
+    },
+    {
+        "id": 1844533,
+        "name": "Hamyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.727661,
+            "lat": 35.519379
+        },
+        "name_ko": "함양"
+    },
+    {
+        "id": 1844539,
+        "name": "Hampyeongsaengtaegongwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.51944,
+            "lat": 35.063889
+        },
+        "name_ko": "함평생태공원"
+    },
+    {
+        "id": 1844751,
+        "name": "Haenam",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.598892,
+            "lat": 34.57111
+        },
+        "name_ko": "해남"
+    },
+    {
+        "id": 1844788,
+        "name": "Hadong-eup Samuso",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.749168,
+            "lat": 35.069439
+        },
+        "name_ko": "하동읍사무소"
+    },
+    {
+        "id": 1844954,
+        "name": "Jungpyong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.58194,
+            "lat": 36.784721
+        },
+        "name_ko": "중평"
+    },
+    {
+        "id": 1845033,
+        "name": "Chungju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.93222,
+            "lat": 36.970558
+        },
+        "name_ko": "충주"
+    },
+    {
+        "id": 1845105,
+        "name": "Chungcheongnam-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 36.5
+        },
+        "name_ko": "충청남도"
+    },
+    {
+        "id": 1845106,
+        "name": "Chungcheongbuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.0,
+            "lat": 36.75
+        },
+        "name_ko": "충청북도"
+    },
+    {
+        "id": 1845136,
+        "name": "Chuncheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.734169,
+            "lat": 37.874722
+        },
+        "name_ko": "춘천"
+    },
+    {
+        "id": 1845275,
+        "name": "Chuja-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.213058,
+            "lat": 37.361938
+        },
+        "name_ko": "추자리"
+    },
+    {
+        "id": 1845457,
+        "name": "Jeonju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.148888,
+            "lat": 35.821941
+        },
+        "name_ko": "전주"
+    },
+    {
+        "id": 1845519,
+        "name": "Cheongsong gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.057007,
+            "lat": 36.43351
+        },
+        "name_ko": "청송군"
+    },
+    {
+        "id": 1845585,
+        "name": "Ch’ŏngnim",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.404724,
+            "lat": 35.991669
+        },
+        "name_ko": "청림"
+    },
+    {
+        "id": 1845604,
+        "name": "Cheongju-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.489723,
+            "lat": 36.637218
+        },
+        "name_ko": "청주시"
+    },
+    {
+        "id": 1845759,
+        "name": "Cheonan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.152199,
+            "lat": 36.806499
+        },
+        "name_ko": "천안"
+    },
+    {
+        "id": 1845788,
+        "name": "Jeollanam-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 34.75
+        },
+        "name_ko": "전라남도"
+    },
+    {
+        "id": 1845789,
+        "name": "Jeollabuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.25,
+            "lat": 35.75
+        },
+        "name_ko": "전라북도"
+    },
+    {
+        "id": 1846052,
+        "name": "Chinju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.084717,
+            "lat": 35.19278
+        },
+        "name_ko": "진주"
+    },
+    {
+        "id": 1846069,
+        "name": "Chinhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.659714,
+            "lat": 35.149441
+        },
+        "name_ko": "진해"
+    },
+    {
+        "id": 1846095,
+        "name": "Chinch'ŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.443329,
+            "lat": 36.85667
+        },
+        "name_ko": "진천"
+    },
+    {
+        "id": 1846114,
+        "name": "Jinan-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.425278,
+            "lat": 35.791672
+        },
+        "name_ko": "진안군"
+    },
+    {
+        "id": 1846149,
+        "name": "Shitsukoku",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.551392,
+            "lat": 35.920559
+        },
+        "name_ko": "칠곡"
+    },
+    {
+        "id": 1846265,
+        "name": "Jeju-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.5,
+            "lat": 33.416672
+        },
+        "name_ko": "제주도"
+    },
+    {
+        "id": 1846266,
+        "name": "Jeju City",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.521942,
+            "lat": 33.50972
+        },
+        "name_ko": "제주시"
+    },
+    {
+        "id": 1846278,
+        "name": "Teisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.211945,
+            "lat": 37.136108
+        },
+        "name_ko": "테이센"
+    },
+    {
+        "id": 1846326,
+        "name": "Changwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.681107,
+            "lat": 35.228062
+        },
+        "name_ko": "창원"
+    },
+    {
+        "id": 1846355,
+        "name": "Changsu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.515228,
+            "lat": 35.648418
+        },
+        "name_ko": "장수"
+    },
+    {
+        "id": 1846430,
+        "name": "Changp’o",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.435013,
+            "lat": 35.381691
+        },
+        "name_ko": "장포"
+    },
+    {
+        "id": 1846589,
+        "name": "Janggol",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.238403,
+            "lat": 36.174702
+        },
+        "name_ko": "장골"
+    },
+    {
+        "id": 1846735,
+        "name": "Jamwon-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.51667
+        },
+        "name_ko": "잠원동"
+    },
+    {
+        "id": 1846898,
+        "name": "Anyang-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.926941,
+            "lat": 37.392502
+        },
+        "name_ko": "안양시"
+    },
+    {
+        "id": 1846912,
+        "name": "Anseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.270279,
+            "lat": 37.01083
+        },
+        "name_ko": "안성"
+    },
+    {
+        "id": 1846918,
+        "name": "Ansan-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.821938,
+            "lat": 37.323608
+        },
+        "name_ko": "안산시"
+    },
+    {
+        "id": 1846986,
+        "name": "Andong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.725006,
+            "lat": 36.565559
+        },
+        "name_ko": "안동"
+    },
+    {
+        "id": 1847050,
+        "name": "Gaigeturi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.318329,
+            "lat": 33.464439
+        },
+        "name_ko": "가개투리"
+    },
+    {
+        "id": 1882056,
+        "name": "Sinhyeon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.626663,
+            "lat": 34.8825
+        },
+        "name_ko": "신현"
+    },
+    {
+        "id": 1883978,
+        "name": "Buyeondong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.256943,
+            "lat": 38.299999
+        },
+        "name_ko": "부연동"
+    },
+    {
+        "id": 1884249,
+        "name": "Kangp’o-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.292503,
+            "lat": 38.117779
+        },
+        "name_ko": "강포리"
+    },
+    {
+        "id": 1885994,
+        "name": "Songch’ŏni-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.112312,
+            "lat": 35.876282
+        },
+        "name_ko": "송천이동"
+    },
+    {
+        "id": 1886130,
+        "name": "Sŏnyŏl-li",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.625832,
+            "lat": 35.896389
+        },
+        "name_ko": "선열리"
+    },
+    {
+        "id": 1886598,
+        "name": "Yŏnmu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.099998,
+            "lat": 36.12944
+        },
+        "name_ko": "연무"
+    },
+    {
+        "id": 1886748,
+        "name": "Unam-ni",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.018333,
+            "lat": 36.561668
+        },
+        "name_ko": "운암리"
+    },
+    {
+        "id": 1890085,
+        "name": "Tangp’yŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.038773,
+            "lat": 37.570621
+        },
+        "name_ko": "당평"
+    },
+    {
+        "id": 1892823,
+        "name": "Tonghae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.106934,
+            "lat": 37.543892
+        },
+        "name_ko": "동해"
+    },
+    {
+        "id": 1895287,
+        "name": "Sŏnbawi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.335556,
+            "lat": 36.63139
+        },
+        "name_ko": "선바위"
+    },
+    {
+        "id": 1896953,
+        "name": "Pubal",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.507782,
+            "lat": 37.291672
+        },
+        "name_ko": "부발"
+    },
+    {
+        "id": 1897000,
+        "name": "Seongnam-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.137779,
+            "lat": 37.43861
+        },
+        "name_ko": "성남시"
+    },
+    {
+        "id": 1897007,
+        "name": "Hanam",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.205559,
+            "lat": 37.540001
+        },
+        "name_ko": "하남"
+    },
+    {
+        "id": 1897118,
+        "name": "Hwado",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.307503,
+            "lat": 37.6525
+        },
+        "name_ko": "화도"
+    },
+    {
+        "id": 1897122,
+        "name": "Namyangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.214172,
+            "lat": 37.636669
+        },
+        "name_ko": "남양주"
+    },
+    {
+        "id": 1902028,
+        "name": "Gyeongsangnam-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.25,
+            "lat": 35.25
+        },
+        "name_ko": "경상남도"
+    },
+    {
+        "id": 1912205,
+        "name": "Ungsang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.16861,
+            "lat": 35.406109
+        },
+        "name_ko": "웅상"
+    },
+    {
+        "id": 1912209,
+        "name": "Wabu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.220284,
+            "lat": 37.589722
+        },
+        "name_ko": "덕소"
+    },
+    {
+        "id": 1925936,
+        "name": "Naesŏ",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.520004,
+            "lat": 35.249722
+        },
+        "name_ko": "내서"
+    },
+    {
+        "id": 1925943,
+        "name": "Hwawŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.500824,
+            "lat": 35.80167
+        },
+        "name_ko": "화원"
+    },
+    {
+        "id": 1930831,
+        "name": "T’aep’ong-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.425278,
+            "lat": 34.847778
+        },
+        "name_ko": "태평동"
+    },
+    {
+        "id": 1948005,
+        "name": "Kwangmyŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.866386,
+            "lat": 37.477219
+        },
+        "name_ko": "광명"
+    },
+    {
+        "id": 1949757,
+        "name": "Kŏje",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.620834,
+            "lat": 34.88472
+        },
+        "name_ko": "거제"
+    },
+    {
+        "id": 1979031,
+        "name": "Seolman",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.928329,
+            "lat": 35.175282
+        },
+        "name_ko": "설만"
+    },
+    {
+        "id": 6367618,
+        "name": "Myŏngwŏli-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.544724,
+            "lat": 38.121941
+        },
+        "name_ko": "명월리"
+    },
+    {
+        "id": 6367665,
+        "name": "Paemŏri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.711113,
+            "lat": 38.11306
+        },
+        "name_ko": "배머리"
+    },
+    {
+        "id": 6395804,
+        "name": "Sinan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.108627,
+            "lat": 34.826199
+        },
+        "name_ko": "신안"
+    }
+]

--- a/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
+++ b/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
@@ -24,6 +24,14 @@ fun SimpleWeatherNavHost() {
                 // 예외 처리 화면
             }
         }
-        composable("search") { CitySearchScreen() }
+        composable("search") {
+            CitySearchScreen(
+                onBackClick = { navController.popBackStack() },
+                onAddCity = { city ->
+                    // 도시 추가 로직 작업 예정 (예: ViewModel에 저장 후 popBackStack)
+                    navController.popBackStack()  // 임시로 뒤로가기 처리만
+                }
+            )
+        }
     }
 }

--- a/app/src/main/java/com/ben/simpleweather/data/City.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/City.kt
@@ -8,8 +8,3 @@ data class City(
     val country: String,
     val coord: Coord
 )
-
-data class Coord(
-    val lon: Double,
-    val lat: Double
-)

--- a/app/src/main/java/com/ben/simpleweather/data/City.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/City.kt
@@ -6,5 +6,5 @@ data class City(
     val nameKo: String,
     val state: String?,
     val country: String,
-    val coord: Coord
+    val coord: Coord,
 )

--- a/app/src/main/java/com/ben/simpleweather/data/City.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/City.kt
@@ -1,0 +1,15 @@
+package com.ben.simpleweather.data
+
+data class City(
+    val id: Int,
+    val name: String,
+    val nameKo: String,
+    val state: String?,
+    val country: String,
+    val coord: Coord
+)
+
+data class Coord(
+    val lon: Double,
+    val lat: Double
+)

--- a/app/src/main/java/com/ben/simpleweather/data/Coord.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/Coord.kt
@@ -2,5 +2,5 @@ package com.ben.simpleweather.data
 
 data class Coord(
     val lon: Double,
-    val lat: Double
+    val lat: Double,
 )

--- a/app/src/main/java/com/ben/simpleweather/data/Coord.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/Coord.kt
@@ -1,0 +1,6 @@
+package com.ben.simpleweather.data
+
+data class Coord(
+    val lon: Double,
+    val lat: Double
+)

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -1,9 +1,147 @@
 package com.ben.simpleweather.features.search
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.ben.simpleweather.data.City
+import com.ben.simpleweather.R
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CitySearchScreen(
+    onBackClick: () -> Unit,
+    onAddCity: (City) -> Unit,
+    viewModel: CitySearchViewModel = hiltViewModel()
+) {
+    val cityList by viewModel.cityList.collectAsState()
+    val isKorean = remember {
+        Locale.getDefault().language == "ko"
+    }
+    var query by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.add_location)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                placeholder = { Text(stringResource(R.string.search_city_placeholder)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxSize()
+            ) {
+                if (cityList.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(stringResource(R.string.no_search_results))
+                        }
+                    }
+                } else {
+                    items(cityList) { city ->
+                        CitySearchResultCard(
+                            name = if (isKorean) city.nameKo else city.name,
+                            country = city.country,
+                            onClick = { onAddCity(city) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun CitySearchScreen() {
-    Text("City Search Screen")
+fun CitySearchResultCard(
+    name: String,
+    country: String,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Text(text = name, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = country,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = onClick) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "${stringResource(R.string.add_city)} $name"
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,16 +16,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -33,11 +36,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.ben.simpleweather.data.City
 import com.ben.simpleweather.R
+import com.ben.simpleweather.data.City
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,18 +53,26 @@ fun CitySearchScreen(
     viewModel: CitySearchViewModel = hiltViewModel()
 ) {
     val cityList by viewModel.cityList.collectAsState()
-    val isKorean = remember {
-        Locale.getDefault().language == "ko"
-    }
+    val isKorean = remember { Locale.getDefault().language == "ko" }
     var query by remember { mutableStateOf("") }
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.add_location)) },
+            CenterAlignedTopAppBar(
+                title = {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(stringResource(R.string.add_location))
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
                     }
                 }
             )
@@ -71,11 +84,39 @@ fun CitySearchScreen(
                 .padding(innerPadding)
                 .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
-            OutlinedTextField(
+            TextField(
                 value = query,
                 onValueChange = { query = it },
-                placeholder = { Text(stringResource(R.string.search_city_placeholder)) },
-                modifier = Modifier.fillMaxWidth()
+                textStyle = MaterialTheme.typography.bodyLarge,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                },
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.search_city_placeholder),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent
+                ),
+                shape = MaterialTheme.shapes.medium,
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 56.dp)
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -20,7 +19,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -45,6 +45,10 @@ import com.ben.simpleweather.R
 import com.ben.simpleweather.data.City
 import java.util.Locale
 
+object Locales {
+    const val KOREAN = "ko"
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CitySearchScreen(
@@ -53,7 +57,7 @@ fun CitySearchScreen(
     viewModel: CitySearchViewModel = hiltViewModel()
 ) {
     val cityList by viewModel.cityList.collectAsState()
-    val isKorean = remember { Locale.getDefault().language == "ko" }
+    val isKorean = remember { Locale.getDefault().language == Locales.KOREAN }
     var query by remember { mutableStateOf("") }
 
     Scaffold(

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -28,6 +29,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -58,19 +60,21 @@ fun CitySearchScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
+            TopAppBar(
                 title = {
                     Box(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = 52.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text(stringResource(R.string.add_location))
+                        Text(text = stringResource(R.string.add_location))
                     }
                 },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.back)
                         )
                     }

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt
@@ -176,7 +176,10 @@ fun CitySearchResultCard(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Column {
-                Text(text = name, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = name,
+                    style = MaterialTheme.typography.titleMedium
+                )
                 Text(
                     text = country,
                     style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/ben/simpleweather/features/search/CitySearchViewModel.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/search/CitySearchViewModel.kt
@@ -1,0 +1,26 @@
+package com.ben.simpleweather.features.search
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import com.ben.simpleweather.data.City
+import com.ben.simpleweather.data.Coord
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CitySearchViewModel @Inject constructor() : ViewModel() {
+
+    private val _cityList = MutableStateFlow<List<City>>(emptyList())
+    val cityList: StateFlow<List<City>> = _cityList
+
+    init {
+        _cityList.value = listOf(
+            City(1, "Seoul", "서울", "", "KR", Coord(126.978, 37.5665)),
+            City(2, "Busan", "부산", "", "KR", Coord(129.0756, 35.1796)),
+            City(3, "Incheon", "인천", "", "KR", Coord(126.7052, 37.4563)),
+            City(4, "Daegu", "대구", "", "KR", Coord(128.6014, 35.8714)),
+            City(5, "Gwangju", "광주", "", "KR", Coord(126.8514, 35.1595))
+        )
+    }
+}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -22,4 +22,7 @@
     <string name="rain_amount">강수량 (3시간)</string>
     <string name="snow_amount">적설량 (3시간)</string>
     <string name="feels_like">체감온도 %1$s°C</string>
+    <string name="add_location">위치 추가</string>
+    <string name="search_city_placeholder">도시명을 입력하세요</string>
+    <string name="no_search_results">검색 결과가 없습니다</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="rain_amount">Rain (3h)</string>
     <string name="snow_amount">Snow (3h)</string>
     <string name="feels_like">Feels like %1$s°C</string>
+    <string name="add_location">Add Location</string>
+    <string name="search_city_placeholder">Enter city name</string>
+    <string name="no_search_results">No search results found</string>
 </resources>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/2b05ad63-8f93-4a73-a398-e7e0a4a2b241" width="400"/>

이 PR은 SimpleWeather 앱에 **도시 검색 기능**을 추가하며, UI 업데이트, 새로운 ViewModel, 도시 추가 기능 등을 포함합니다. 사용자는 이제 도시를 검색하고 리스트에 추가할 수 있으며, 앱의 기능성과 사용자 경험이 향상되었습니다.

## 주요 변경 사항

### 기능 추가: 도시 검색 및 추가

- **도시 검색 화면 구현**  
  `CitySearchScreen`을 리팩토링하여 검색창, 결과 리스트, 도시 추가 콜백을 포함  
  `CitySearchResultCard` 컴포저블 추가  
  (`app/src/main/java/com/ben/simpleweather/features/search/CitySearchScreen.kt`)

- **CitySearchViewModel 추가**  
  도시 검색 상태 및 샘플 데이터를 관리하는 ViewModel  
  (`app/src/main/java/com/ben/simpleweather/features/search/CitySearchViewModel.kt`)

- **City 데이터 모델 정의**  
  도시 이름, 국가, 좌표 정보를 포함하는 `City` 데이터 클래스  
  (`app/src/main/java/com/ben/simpleweather/data/City.kt`)

### 내비게이션 개선

- **NavHost 수정**  
  `SimpleWeatherNavHost`에서 도시 추가 및 뒤로가기 처리를 위한 콜백을 `CitySearchScreen`에 전달  
  (`app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt`)

### 다국어 지원

- **도시 검색 관련 문자열 리소스 추가**  
  영어와 한국어 strings.xml에 도시 검색 기능 관련 텍스트 추가  
  (`app/src/main/res/values/strings.xml`, `app/src/main/res/values-ko/strings.xml`)

---

closes #5
