### PR TITLE
Feature/#6 #7 #8 api bringup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,12 @@ android {
 
         val properties = Properties()
         properties.load(project.rootProject.file("local.properties").inputStream())
+        val apiKey = properties.getProperty("WEATHER_API_KEY") // API 키 가져오기
+
+        if (apiKey.isNullOrEmpty()) {
+            // API 키가 null이거나 비어있으면 빌드 오류 발생
+            throw GradleException("local.properties 파일에 WEATHER_API_KEY가 없거나 비어있습니다. 추가해주세요.")
+        }
         buildConfigField("String", "WEATHER_API_KEY", "\"${properties.getProperty("WEATHER_API_KEY")}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -22,6 +24,10 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
+
+        val properties = Properties()
+        properties.load(project.rootProject.file("local.properties").inputStream())
+        buildConfigField("String", "WEATHER_API_KEY", "\"${properties.getProperty("WEATHER_API_KEY")}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/ben/simpleweather/data/remote/dto/ForecastResponse.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/remote/dto/ForecastResponse.kt
@@ -9,7 +9,7 @@ data class ForecastResponse(
     val message: Int? = null,
     val cnt: Int? = null,
     val list: List<ForecastItemDto>? = null,
-    val city: CityDto? = null
+    val city: CityDto? = null,
 )
 
 @Serializable
@@ -25,7 +25,7 @@ data class ForecastItemDto(
     val snow: SnowDto? = null, // Reusing SnowDto
     val sys: ForecastSysDto? = null, // Different SysDto for forecast
     @SerialName("dt_txt")
-    val dtTxt: String? = null
+    val dtTxt: String? = null,
 )
 
 @Serializable
@@ -42,6 +42,6 @@ data class CityDto(
     val population: Int? = null,
     val timezone: Int? = null,
     val sunrise: Long? = null,
-    val sunset: Long? = null
+    val sunset: Long? = null,
 )
 

--- a/app/src/main/java/com/ben/simpleweather/data/remote/dto/ForecastResponse.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/remote/dto/ForecastResponse.kt
@@ -1,0 +1,47 @@
+package com.ben.simpleweather.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ForecastResponse(
+    val cod: String? = null,
+    val message: Int? = null,
+    val cnt: Int? = null,
+    val list: List<ForecastItemDto>? = null,
+    val city: CityDto? = null
+)
+
+@Serializable
+data class ForecastItemDto(
+    val dt: Long? = null,
+    val main: MainDto? = null, // Reusing MainDto from WeatherResponse.kt
+    val weather: List<WeatherDto>? = null, // Reusing WeatherDto
+    val clouds: CloudsDto? = null, // Reusing CloudsDto
+    val wind: WindDto? = null, // Reusing WindDto
+    val visibility: Int? = null,
+    val pop: Double? = null, // Probability of precipitation
+    val rain: RainDto? = null, // Reusing RainDto
+    val snow: SnowDto? = null, // Reusing SnowDto
+    val sys: ForecastSysDto? = null, // Different SysDto for forecast
+    @SerialName("dt_txt")
+    val dtTxt: String? = null
+)
+
+@Serializable
+data class ForecastSysDto( // Specific SysDto for forecast items
+    val pod: String? = null // Part of day (d = day, n = night)
+)
+
+@Serializable
+data class CityDto(
+    val id: Int? = null,
+    val name: String? = null,
+    val coord: CoordDto? = null, // Reusing CoordDto
+    val country: String? = null,
+    val population: Int? = null,
+    val timezone: Int? = null,
+    val sunrise: Long? = null,
+    val sunset: Long? = null
+)
+

--- a/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
@@ -1,0 +1,94 @@
+package com.ben.simpleweather.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherResponse(
+    val coord: CoordDto? = null,
+    val weather: List<WeatherDto>? = null,
+    val base: String? = null,
+    val main: MainDto? = null,
+    val visibility: Int? = null,
+    val wind: WindDto? = null,
+    val clouds: CloudsDto? = null,
+    val rain: RainDto? = null,
+    val snow: SnowDto? = null,
+    val dt: Long? = null,
+    val sys: SysDto? = null,
+    val timezone: Int? = null,
+    val id: Int? = null,
+    val name: String? = null,
+    val cod: Int? = null
+)
+
+@Serializable
+data class CoordDto(
+    val lon: Double? = null,
+    val lat: Double? = null
+)
+
+@Serializable
+data class WeatherDto(
+    val id: Int? = null,
+    val main: String? = null,
+    val description: String? = null,
+    val icon: String? = null
+)
+
+@Serializable
+data class MainDto(
+    val temp: Double? = null,
+    @SerialName("feels_like")
+    val feelsLike: Double? = null,
+    @SerialName("temp_min")
+    val tempMin: Double? = null,
+    @SerialName("temp_max")
+    val tempMax: Double? = null,
+    val pressure: Int? = null,
+    val humidity: Int? = null,
+    @SerialName("sea_level")
+    val seaLevel: Int? = null,
+    @SerialName("grnd_level")
+    val grndLevel: Int? = null,
+    // Forecast specific field, adding here for reusability if MainDto is used for forecast items
+    val temp_kf: Double? = null
+)
+
+@Serializable
+data class WindDto(
+    val speed: Double? = null,
+    val deg: Int? = null,
+    val gust: Double? = null
+)
+
+@Serializable
+data class CloudsDto(
+    val all: Int? = null
+)
+
+@Serializable
+data class RainDto(
+    @SerialName("1h")
+    val oneHour: Double? = null,
+    @SerialName("3h")
+    val threeHours: Double? = null
+)
+
+@Serializable
+data class SnowDto(
+    @SerialName("1h")
+    val oneHour: Double? = null,
+    @SerialName("3h")
+    val threeHours: Double? = null
+)
+
+@Serializable
+data class SysDto( // For Current Weather
+    val type: Int? = null,
+    val id: Int? = null,
+    val country: String? = null,
+    val sunrise: Long? = null,
+    val sunset: Long? = null
+)
+

--- a/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
@@ -19,13 +19,13 @@ data class WeatherResponse(
     val timezone: Int? = null,
     val id: Int? = null,
     val name: String? = null,
-    val cod: Int? = null
+    val cod: Int? = null,
 )
 
 @Serializable
 data class CoordDto(
     val lon: Double? = null,
-    val lat: Double? = null
+    val lat: Double? = null,
 )
 
 @Serializable
@@ -33,7 +33,7 @@ data class WeatherDto(
     val id: Int? = null,
     val main: String? = null,
     val description: String? = null,
-    val icon: String? = null
+    val icon: String? = null,
 )
 
 @Serializable
@@ -52,19 +52,19 @@ data class MainDto(
     @SerialName("grnd_level")
     val grndLevel: Int? = null,
     // Forecast specific field, adding here for reusability if MainDto is used for forecast items
-    val temp_kf: Double? = null
+    val temp_kf: Double? = null,
 )
 
 @Serializable
 data class WindDto(
     val speed: Double? = null,
     val deg: Int? = null,
-    val gust: Double? = null
+    val gust: Double? = null,
 )
 
 @Serializable
 data class CloudsDto(
-    val all: Int? = null
+    val all: Int? = null,
 )
 
 @Serializable
@@ -72,7 +72,7 @@ data class RainDto(
     @SerialName("1h")
     val oneHour: Double? = null,
     @SerialName("3h")
-    val threeHours: Double? = null
+    val threeHours: Double? = null,
 )
 
 @Serializable
@@ -80,7 +80,7 @@ data class SnowDto(
     @SerialName("1h")
     val oneHour: Double? = null,
     @SerialName("3h")
-    val threeHours: Double? = null
+    val threeHours: Double? = null,
 )
 
 @Serializable
@@ -89,6 +89,6 @@ data class SysDto( // For Current Weather
     val id: Int? = null,
     val country: String? = null,
     val sunrise: Long? = null,
-    val sunset: Long? = null
+    val sunset: Long? = null,
 )
 

--- a/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/remote/dto/WeatherResponse.kt
@@ -52,7 +52,8 @@ data class MainDto(
     @SerialName("grnd_level")
     val grndLevel: Int? = null,
     // Forecast specific field, adding here for reusability if MainDto is used for forecast items
-    val temp_kf: Double? = null,
+    @SerialName("temp_kf")
+    val tempKf: Double? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/ben/simpleweather/di/NetworkModule.kt
+++ b/app/src/main/java/com/ben/simpleweather/di/NetworkModule.kt
@@ -1,13 +1,16 @@
 package com.ben.simpleweather.di
 
+import com.ben.simpleweather.BuildConfig // BuildConfig 임포트 추가
 import com.ben.simpleweather.network.WeatherApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Singleton
@@ -22,7 +25,7 @@ object NetworkModule {
     @Singleton
     fun provideJson(): Json = Json {
         ignoreUnknownKeys = true
-        coerceInputValues = true // 기본값을 위해 추가 (optional)
+        coerceInputValues = true
     }
 
     @Provides
@@ -30,13 +33,20 @@ object NetworkModule {
     fun provideOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor { chain ->
-                val original = chain.request()
-                val requestBuilder = original.newBuilder()
+                val original: Request = chain.request()
+                val originalHttpUrl: HttpUrl = original.url
+
+                // API 키를 쿼리 파라미터로 추가
+                val url: HttpUrl = originalHttpUrl.newBuilder()
+                    .addQueryParameter("appid", BuildConfig.WEATHER_API_KEY)
+                    .build()
+
+                // Content-Type 헤더 추가 및 요청 재구성
+                val requestBuilder: Request.Builder = original.newBuilder()
+                    .url(url)
                     .header("Content-Type", "application/json")
-                // 여기에 API 키를 자동으로 추가하는 로직을 넣을 수도 있습니다.
-                // .header("Authorization", "Bearer YOUR_API_KEY") or
-                // .url(original.url.newBuilder().addQueryParameter("appid", "YOUR_API_KEY").build())
-                val request = requestBuilder.build()
+
+                val request: Request = requestBuilder.build()
                 chain.proceed(request)
             }
             .build()

--- a/app/src/main/java/com/ben/simpleweather/di/NetworkModule.kt
+++ b/app/src/main/java/com/ben/simpleweather/di/NetworkModule.kt
@@ -1,0 +1,61 @@
+package com.ben.simpleweather.di
+
+import com.ben.simpleweather.network.WeatherApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val BASE_URL = "https://api.openweathermap.org/"
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true // 기본값을 위해 추가 (optional)
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val requestBuilder = original.newBuilder()
+                    .header("Content-Type", "application/json")
+                // 여기에 API 키를 자동으로 추가하는 로직을 넣을 수도 있습니다.
+                // .header("Authorization", "Bearer YOUR_API_KEY") or
+                // .url(original.url.newBuilder().addQueryParameter("appid", "YOUR_API_KEY").build())
+                val request = requestBuilder.build()
+                chain.proceed(request)
+            }
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideWeatherApi(retrofit: Retrofit): WeatherApi {
+        return retrofit.create(WeatherApi::class.java)
+    }
+}
+

--- a/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
+++ b/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
@@ -1,0 +1,28 @@
+package com.ben.simpleweather.network
+
+import com.ben.simpleweather.data.remote.dto.ForecastResponse
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WeatherApi {
+
+    @GET("data/2.5/weather")
+    suspend fun getCurrentWeather(
+        @Query("lat") latitude: Double,
+        @Query("lon") longitude: Double,
+        @Query("appid") apiKey: String,
+        @Query("units") units: String = "metric", // metric for Celsius, standard for Kelvin, imperial for Fahrenheit
+        @Query("lang") lang: String = "kr" // Korean language
+    ): WeatherResponse
+
+    @GET("data/2.5/forecast")
+    suspend fun getWeatherForecast(
+        @Query("lat") latitude: Double,
+        @Query("lon") longitude: Double,
+        @Query("appid") apiKey: String,
+        @Query("units") units: String = "metric",
+        @Query("lang") lang: String = "kr",
+        @Query("cnt") count: Int? = null // Optional: A number of timestamps, which will be returned in the API response.
+    ): ForecastResponse
+}

--- a/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
+++ b/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
@@ -11,18 +11,16 @@ interface WeatherApi {
     suspend fun getCurrentWeather(
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
-        @Query("appid") apiKey: String,
-        @Query("units") units: String = "metric", // metric for Celsius, standard for Kelvin, imperial for Fahrenheit
-        @Query("lang") lang: String = "kr" // Korean language
+        @Query("units") units: String = "metric",
+        @Query("lang") lang: String = "kr"
     ): WeatherResponse
 
     @GET("data/2.5/forecast")
     suspend fun getWeatherForecast(
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
-        @Query("appid") apiKey: String,
         @Query("units") units: String = "metric",
         @Query("lang") lang: String = "kr",
-        @Query("cnt") count: Int? = null // Optional: A number of timestamps, which will be returned in the API response.
+        @Query("cnt") count: Int? = null
     ): ForecastResponse
 }

--- a/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
+++ b/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
@@ -1,0 +1,102 @@
+package com.ben.simpleweather.network
+
+import com.ben.simpleweather.BuildConfig // API 키를 위해 BuildConfig 임포트
+import com.ben.simpleweather.data.remote.dto.ForecastResponse
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory // 유지된 import
+
+class WeatherApiTest {
+
+    private lateinit var weatherApi: WeatherApi
+    private val seoulLatitude = 37.5665
+    private val seoulLongitude = 126.9780
+
+    @Before
+    fun setUp() {
+        if (BuildConfig.WEATHER_API_KEY.isEmpty()) {
+            throw IllegalStateException("WEATHER_API_KEY in BuildConfig is empty. Ensure it's set in local.properties and Gradle sync is complete.")
+        }
+
+        val json = Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true // DTO의 기본값을 활용하기 위함
+        }
+
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val original: Request = chain.request()
+                val originalHttpUrl: HttpUrl = original.url
+
+                val url: HttpUrl = originalHttpUrl.newBuilder()
+                    .addQueryParameter("appid", BuildConfig.WEATHER_API_KEY)
+                    .build()
+
+                val requestBuilder: Request.Builder = original.newBuilder()
+                    .url(url)
+                    .header("Content-Type", "application/json")
+
+                val request: Request = requestBuilder.build()
+                chain.proceed(request)
+            }
+            .build()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl("https://api.openweathermap.org/")
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        weatherApi = retrofit.create(WeatherApi::class.java)
+    }
+
+    @Test
+    fun `getCurrentWeather for Seoul should return current weather data`() = runBlocking {
+        // API 호출
+        val response: WeatherResponse = weatherApi.getCurrentWeather(
+            latitude = seoulLatitude,
+            longitude = seoulLongitude
+            // units와 lang은 WeatherApi 인터페이스에 정의된 기본값 사용
+        )
+        println("Current Weather Response: $response") // 응답 내용 출력 추가
+
+        // 응답 검증
+        assertNotNull("Response body should not be null", response)
+        assertEquals("Response code (cod) should be 200", 200, response.cod)
+        assertNotNull("Weather list should not be null", response.weather)
+        assertTrue("Weather list should not be empty", response.weather?.isNotEmpty() == true)
+        assertNotNull("Main data (temp, humidity etc.) should not be null", response.main)
+        // API가 반환하는 도시 이름이 "Seoul"과 정확히 일치하는지 확인 (약간의 변동 가능성 있음)
+        assertEquals("City name should be Seoul", "Seoul", response.name)
+    }
+
+    @Test
+    fun `getWeatherForecast for Seoul should return forecast data`() = runBlocking {
+        // API 호출
+        val response: ForecastResponse = weatherApi.getWeatherForecast(
+            latitude = seoulLatitude,
+            longitude = seoulLongitude
+            // units, lang, cnt는 WeatherApi 인터페이스에 정의된 기본값 또는 null 사용
+        )
+        println("Weather Forecast Response: $response") // 응답 내용 출력 추가
+
+        // 응답 검증
+        assertNotNull("Response body should not be null", response)
+        assertEquals("Response code (cod) should be \"200\"", "200", response.cod) // Forecast API의 cod는 String 타입
+        assertNotNull("Forecast list should not be null", response.list)
+        assertTrue("Forecast list should not be empty", response.list?.isNotEmpty() == true)
+        assertNotNull("City data should not be null", response.city)
+        assertEquals("City name should be Seoul", "Seoul", response.city?.name)
+    }
+}

--- a/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
+++ b/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
@@ -25,7 +25,7 @@ class WeatherApiTest {
 
     @Before
     fun setUp() {
-        if (BuildConfig.WEATHER_API_KEY.isEmpty()) {
+        check(!(BuildConfig.WEATHER_API_KEY.isEmpty())){
             throw IllegalStateException("WEATHER_API_KEY in BuildConfig is empty. Ensure it's set in local.properties and Gradle sync is complete.")
         }
 
@@ -62,7 +62,7 @@ class WeatherApiTest {
     }
 
     @Test
-    fun `getCurrentWeather for Seoul should return current weather data`() = runBlocking {
+    fun getCurrentWeatherForSeoulShouldReturnCurrentWeatherData() = runBlocking {
         // API 호출
         val response: WeatherResponse = weatherApi.getCurrentWeather(
             latitude = seoulLatitude,
@@ -80,7 +80,7 @@ class WeatherApiTest {
     }
 
     @Test
-    fun `getWeatherForecast for Seoul should return forecast data`() = runBlocking {
+    fun getWeatherForecastForSeoulShouldReturnForecastData() = runBlocking {
         // API 호출
         val response: ForecastResponse = weatherApi.getWeatherForecast(
             latitude = seoulLatitude,

--- a/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
+++ b/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
@@ -1,6 +1,6 @@
 package com.ben.simpleweather.network
 
-import com.ben.simpleweather.BuildConfig // API 키를 위해 BuildConfig 임포트
+import com.ben.simpleweather.BuildConfig
 import com.ben.simpleweather.data.remote.dto.ForecastResponse
 import com.ben.simpleweather.data.remote.dto.WeatherResponse
 import kotlinx.coroutines.runBlocking
@@ -15,7 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
-import retrofit2.converter.kotlinx.serialization.asConverterFactory // 유지된 import
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 class WeatherApiTest {
 
@@ -69,8 +69,6 @@ class WeatherApiTest {
             longitude = seoulLongitude
             // units와 lang은 WeatherApi 인터페이스에 정의된 기본값 사용
         )
-        println("Current Weather Response: $response") // 응답 내용 출력 추가
-
         // 응답 검증
         assertNotNull("Response body should not be null", response)
         assertEquals("Response code (cod) should be 200", 200, response.cod)

--- a/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
+++ b/app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.kt
@@ -87,8 +87,6 @@ class WeatherApiTest {
             longitude = seoulLongitude
             // units, lang, cnt는 WeatherApi 인터페이스에 정의된 기본값 또는 null 사용
         )
-        println("Weather Forecast Response: $response") // 응답 내용 출력 추가
-
         // 응답 검증
         assertNotNull("Response body should not be null", response)
         assertEquals("Response code (cod) should be \"200\"", "200", response.cod) // Forecast API의 cod는 String 타입


### PR DESCRIPTION
이 풀 리퀘스트는 날씨 데이터 조회 기능을 프로젝트에 통합하기 위한 주요 기능들을 추가합니다. 이번 변경사항에는 API 응답을 위한 DTO 추가, Retrofit과 OkHttp를 활용한 네트워크 모듈 구성, 날씨 API 인터페이스 구현, 그리고 API 테스트 코드 작성이 포함되어 있습니다. 또한 `local.properties` 파일을 활용하여 날씨 API 키를 안전하게 관리합니다.

### 🌐 API 연동 및 네트워크 구성

* **API 응답 DTO 추가**  
  `WeatherResponse`, `ForecastResponse` 등 OpenWeatherMap API 응답을 매핑하기 위한 데이터 클래스를 `app/src/main/java/com/ben/simpleweather/data/remote/dto/` 디렉토리에 추가했습니다. 공통으로 재사용되는 구성 요소(`MainDto`, `WeatherDto` 등)도 포함되어 있습니다.  
  ([보기](diffhunk://#diff-0e6c4d4e363a98225919e491ade7c2d21970b1926f9040e44530dff7f1814431R1-R47), [보기](diffhunk://#diff-1b7481216325b1d63ba9215d0b1bbe2dca4b5fb51211a5a1bf0d1488f9c17b97R1-R94))

* **네트워크 모듈 구현**  
  `NetworkModule.kt` 파일을 추가하여 Retrofit, Kotlin Serialization, OkHttp 설정을 구성했습니다. 모든 요청에 API 키가 자동으로 포함되도록 인터셉터를 추가했습니다.  
  ([app/src/main/java/com/ben/simpleweather/di/NetworkModule.ktR1-R71](diffhunk://#diff-01a49f19ad97f585db964f7ddbab2be69800e0ff63d864eeaf0163c591c336d0R1-R71))

* **날씨 API 인터페이스 생성**  
  현재 날씨 및 예보 정보를 가져오기 위한 `WeatherApi` 인터페이스를 정의했습니다.  
  ([app/src/main/java/com/ben/simpleweather/network/WeatherApi.ktR1-R26](diffhunk://#diff-c1e6d68d92879b66a6fd4f490871535a37fe2ec0a61090fe96d7a88b3291dad2R1-R26))

### ⚙️ 설정 및 빌드 구성

* **API 키 관리 추가**  
  `local.properties` 파일에서 API 키를 로드하고, `build.gradle.kts`를 수정하여 빌드 설정에 주입되도록 구성했습니다.  
  ([보기](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R1-R2), [보기](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R28-R31))

### ✅ 테스트

* **API 통합 테스트 추가**  
  실제 API 호출을 통해 `WeatherApi`의 동작을 검증하는 테스트 코드(`WeatherApiTest`)를 작성했습니다. 응답값에 대한 검증도 포함되어 있습니다.  
  ([app/src/test/java/com/ben/simpleweather/network/WeatherApiTest.ktR1-R102](diffhunk://#diff-9ef65b5ace4812f57dd331f160475638fdf450eca0089047956078b904836fa0R1-R102))

---

closes #6  
closes #7  
closes #8
