### PR TITLE
feat: 상세 화면 ViewModel 구현 및 날씨 데이터 처리

### DIFF
--- a/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
+++ b/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
@@ -1,9 +1,11 @@
 package com.ben.simpleweather
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.ben.simpleweather.features.detail.WeatherDetailScreen
 import com.ben.simpleweather.features.main.WeatherListScreen
 import com.ben.simpleweather.features.search.CitySearchScreen
@@ -13,7 +15,10 @@ fun SimpleWeatherNavHost() {
     val navController = rememberNavController()
     NavHost(navController = navController, startDestination = "main") {
         composable("main") { WeatherListScreen(navController = navController) }
-        composable("detail/{cityid}") { backStackEntry ->
+        composable(
+            route = "detail/{cityid}",
+            arguments = listOf(navArgument("cityid") { type = NavType.IntType })
+        ) { backStackEntry ->
             val cityid = backStackEntry.arguments?.getInt("cityid")
             if (cityid != null) {
                 WeatherDetailScreen(

--- a/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
+++ b/app/src/main/java/com/ben/simpleweather/SimpleWeatherNavHost.kt
@@ -13,11 +13,11 @@ fun SimpleWeatherNavHost() {
     val navController = rememberNavController()
     NavHost(navController = navController, startDestination = "main") {
         composable("main") { WeatherListScreen(navController = navController) }
-        composable("detail/{cityName}") { backStackEntry ->
-            val cityName = backStackEntry.arguments?.getString("cityName")
-            if (cityName != null) {
+        composable("detail/{cityid}") { backStackEntry ->
+            val cityid = backStackEntry.arguments?.getInt("cityid")
+            if (cityid != null) {
                 WeatherDetailScreen(
-                    cityName = cityName,
+                    cityid = cityid,
                     navController = navController
                 )
             } else {

--- a/app/src/main/java/com/ben/simpleweather/data/CachedWeather.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/CachedWeather.kt
@@ -1,0 +1,8 @@
+package com.ben.simpleweather.data
+
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+
+data class CachedWeather(
+    val weather: WeatherResponse,
+    val timestamp: Long // 저장된 시간 (System.currentTimeMillis())
+)

--- a/app/src/main/java/com/ben/simpleweather/data/CachedWeather.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/CachedWeather.kt
@@ -4,5 +4,5 @@ import com.ben.simpleweather.data.remote.dto.WeatherResponse
 
 data class CachedWeather(
     val weather: WeatherResponse,
-    val timestamp: Long // 저장된 시간 (System.currentTimeMillis())
+    val timestamp: Long
 )

--- a/app/src/main/java/com/ben/simpleweather/data/WeatherItem.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/WeatherItem.kt
@@ -1,7 +1,9 @@
 package com.ben.simpleweather.data
 
 data class WeatherItem(
+    val city: City,
     val cityName: String,
     val temperature: Int,
     val weatherType: String,
+    val iconCode: String,
 )

--- a/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepository.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepository.kt
@@ -6,4 +6,5 @@ interface CityStorageRepository {
     suspend fun getSavedCities(): List<City>
     suspend fun addCity(city: City)
     suspend fun removeCities(cities: List<City>)
+    suspend fun getCityById(id: Int): City?
 }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepository.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepository.kt
@@ -5,4 +5,5 @@ import com.ben.simpleweather.data.City
 interface CityStorageRepository {
     suspend fun getSavedCities(): List<City>
     suspend fun addCity(city: City)
+    suspend fun removeCities(cities: List<City>)
 }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepositoryImpl.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepositoryImpl.kt
@@ -23,7 +23,7 @@ class CityStorageRepositoryImpl @Inject constructor(
         val json = prefs[key] ?: return emptyList()
         return try {
             Json.decodeFromString(json)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             emptyList()
         }
     }
@@ -31,7 +31,17 @@ class CityStorageRepositoryImpl @Inject constructor(
     override suspend fun addCity(city: City) {
         val current = getSavedCities().toMutableList()
         current.add(city)
-        val updatedJson = Json.encodeToString(current)
+        saveCities(current)
+    }
+
+    override suspend fun removeCities(cities: List<City>) {
+        val current = getSavedCities()
+        val updated = current.filterNot { city -> cities.any { it.id == city.id } }
+        saveCities(updated)
+    }
+
+    private suspend fun saveCities(cities: List<City>) {
+        val updatedJson = Json.encodeToString(cities)
         context.dataStore.edit { prefs ->
             prefs[key] = updatedJson
         }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepositoryImpl.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/CityStorageRepositoryImpl.kt
@@ -46,4 +46,8 @@ class CityStorageRepositoryImpl @Inject constructor(
             prefs[key] = updatedJson
         }
     }
+
+    override suspend fun getCityById(id: Int): City? {
+        return getSavedCities().find { it.id == id }
+    }
 }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepository.kt
@@ -1,0 +1,11 @@
+package com.ben.simpleweather.data.repository
+
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+
+interface WeatherRepository {
+    suspend fun getWeather(
+        cityId: Int,
+        latitude: Double,
+        longitude: Double,
+    ): WeatherResponse
+}

--- a/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepository.kt
@@ -1,5 +1,6 @@
 package com.ben.simpleweather.data.repository
 
+import com.ben.simpleweather.data.remote.dto.ForecastResponse
 import com.ben.simpleweather.data.remote.dto.WeatherResponse
 
 interface WeatherRepository {
@@ -8,4 +9,9 @@ interface WeatherRepository {
         latitude: Double,
         longitude: Double,
     ): WeatherResponse
+
+    suspend fun getForecast(
+        lat: Double,
+        lon: Double,
+    ): ForecastResponse
 }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepositoryImpl.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.ben.simpleweather.data.repository
 
 import com.ben.simpleweather.data.CachedWeather
+import com.ben.simpleweather.data.remote.dto.ForecastResponse
 import com.ben.simpleweather.data.remote.dto.WeatherResponse
 import com.ben.simpleweather.network.WeatherApi
 import jakarta.inject.Inject
@@ -14,7 +15,7 @@ class WeatherRepositoryImpl @Inject constructor(
     private val cacheDurationMillis = 30 * 60 * 1000L // 30분
 
     override suspend fun getWeather(cityId: Int, latitude: Double, longitude: Double): WeatherResponse {
-        val lang = if (Locale.getDefault().language == "ko") "kr" else "en"
+        val lang = getLang()
 
         val now = System.currentTimeMillis()
         val cached = weatherCache[cityId]
@@ -27,4 +28,11 @@ class WeatherRepositoryImpl @Inject constructor(
             weather
         }
     }
+
+    override suspend fun getForecast(lat: Double, lon: Double): ForecastResponse {
+        val lang = getLang()
+        return api.getWeatherForecast(lat, lon, lang = lang)
+    }
+
+    private fun getLang(): String = if (Locale.getDefault().language == "ko") "kr" else "en"
 }

--- a/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepositoryImpl.kt
+++ b/app/src/main/java/com/ben/simpleweather/data/repository/WeatherRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.ben.simpleweather.data.repository
+
+import com.ben.simpleweather.data.CachedWeather
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+import com.ben.simpleweather.network.WeatherApi
+import jakarta.inject.Inject
+import java.util.Locale
+
+class WeatherRepositoryImpl @Inject constructor(
+    private val api: WeatherApi
+) : WeatherRepository {
+
+    private val weatherCache = mutableMapOf<Int, CachedWeather>() // cityId → CachedWeather
+    private val cacheDurationMillis = 30 * 60 * 1000L // 30분
+
+    override suspend fun getWeather(cityId: Int, latitude: Double, longitude: Double): WeatherResponse {
+        val lang = if (Locale.getDefault().language == "ko") "kr" else "en"
+
+        val now = System.currentTimeMillis()
+        val cached = weatherCache[cityId]
+
+        return if (cached != null && now - cached.timestamp < cacheDurationMillis) {
+            cached.weather
+        } else {
+            val weather = api.getCurrentWeather(latitude, longitude, lang = lang)
+            weatherCache[cityId] = CachedWeather(weather, now)
+            weather
+        }
+    }
+}

--- a/app/src/main/java/com/ben/simpleweather/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ben/simpleweather/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.ben.simpleweather.data.repository.CitySearchRepository
 import com.ben.simpleweather.data.repository.CitySearchRepositoryImpl
 import com.ben.simpleweather.data.repository.CityStorageRepository
 import com.ben.simpleweather.data.repository.CityStorageRepositoryImpl
+import com.ben.simpleweather.data.repository.WeatherRepository
+import com.ben.simpleweather.data.repository.WeatherRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -25,4 +27,10 @@ abstract class RepositoryModule {
     abstract fun bindCityStorageRepository(
         impl: CityStorageRepositoryImpl
     ): CityStorageRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindWeatherRepository(
+        impl: WeatherRepositoryImpl
+    ): WeatherRepository
 }

--- a/app/src/main/java/com/ben/simpleweather/features/Utils.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/Utils.kt
@@ -1,0 +1,19 @@
+package com.ben.simpleweather.features
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ben.simpleweather.features.detail.WEATHER_ICON_BASE_URL
+
+@Composable
+fun WeatherIcon(iconCode: String, size: Dp = 60.dp, modifier: Modifier = Modifier) {
+    val iconUrl = "${WEATHER_ICON_BASE_URL}${iconCode}@2x.png"
+    AsyncImage(
+        model = iconUrl,
+        contentDescription = null,
+        modifier = modifier.size(size)
+    )
+}

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
@@ -41,6 +41,7 @@ import coil.compose.AsyncImage
 import com.ben.simpleweather.R
 import com.ben.simpleweather.data.ForecastItem
 import com.ben.simpleweather.data.WeatherDetail
+import com.ben.simpleweather.features.WeatherIcon
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -284,17 +285,6 @@ fun DetailRow(
             )
         }
     }
-}
-
-
-@Composable
-fun WeatherIcon(iconCode: String, size: Dp = 60.dp, modifier: Modifier = Modifier) {
-    val iconUrl = "${WEATHER_ICON_BASE_URL}${iconCode}@2x.png"
-    AsyncImage(
-        model = iconUrl,
-        contentDescription = null,
-        modifier = modifier.size(size)
-    )
 }
 
 fun degToCompass(deg: Int): String {

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
@@ -60,15 +60,21 @@ fun WeatherDetailScreen(
     viewModel: WeatherDetailViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val cityName by viewModel.cityName.collectAsState()
 
     LaunchedEffect(cityid) {
-        viewModel.loadWeather()
+        viewModel.loadWeather(cityid)
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { },
+                title = {
+                    Text(
+                        text = cityName ?: "",
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
@@ -55,7 +55,7 @@ val directions = listOf(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeatherDetailScreen(
-    cityName: String,
+    cityid: Int,
     navController: NavController,
     viewModel: WeatherDetailViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
@@ -34,10 +34,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import coil.compose.AsyncImage
 import com.ben.simpleweather.R
 import com.ben.simpleweather.data.ForecastItem
 import com.ben.simpleweather.data.WeatherDetail

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailScreen.kt
@@ -61,14 +61,14 @@ fun WeatherDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(cityName) {
+    LaunchedEffect(cityid) {
         viewModel.loadWeather()
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(cityName) },
+                title = { },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.ben.simpleweather.features.detail
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ben.simpleweather.data.ForecastItem
@@ -51,7 +50,7 @@ class WeatherDetailViewModel @Inject constructor(
                 val forecastList = forecast.toForecastList()
 
                 _uiState.value = WeatherUiState.Success(weatherDetail, forecastList)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 _uiState.value = WeatherUiState.Error("날씨 데이터를 불러오는 데 실패했습니다.")
             }
         }

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.ben.simpleweather.features.detail
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ben.simpleweather.data.ForecastItem
@@ -44,7 +45,9 @@ class WeatherDetailViewModel @Inject constructor(
                 val weather = weatherRepository.getWeather(city.id, city.coord.lat, city.coord.lon)
                 val forecast = weatherRepository.getForecast(city.coord.lat, city.coord.lon)
 
-                val weatherDetail = weather.toWeatherDetail()
+                val precipitationChance = (forecast.list?.firstOrNull()?.pop?.toFloat() ?: 0f) * 100f
+
+                val weatherDetail = weather.toWeatherDetail(precipitationChance)
                 val forecastList = forecast.toForecastList()
 
                 _uiState.value = WeatherUiState.Success(weatherDetail, forecastList)
@@ -71,7 +74,7 @@ class WeatherDetailViewModel @Inject constructor(
         }.orEmpty()
     }
 
-    fun WeatherResponse.toWeatherDetail(): WeatherDetail {
+    fun WeatherResponse.toWeatherDetail(precipitationChance: Float): WeatherDetail {
         return WeatherDetail(
             temperature = main?.temp?.toInt() ?: 0,
             feelsLike = main?.feelsLike?.toInt() ?: 0,
@@ -79,7 +82,7 @@ class WeatherDetailViewModel @Inject constructor(
             iconCode = weather?.firstOrNull()?.icon.orEmpty(),
             humidity = main?.humidity ?: 0,
             windSpeed = wind?.speed?.toInt() ?: 0,
-            precipitationChance = 0f,
+            precipitationChance = precipitationChance,
             visibility = visibility ?: 0,
             cloudiness = clouds?.all ?: 0,
             windDegree = wind?.deg ?: 0,

--- a/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/detail/WeatherDetailViewModel.kt
@@ -4,53 +4,91 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ben.simpleweather.data.ForecastItem
 import com.ben.simpleweather.data.WeatherDetail
+import com.ben.simpleweather.data.remote.dto.ForecastResponse
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+import com.ben.simpleweather.data.repository.CityStorageRepository
+import com.ben.simpleweather.data.repository.WeatherRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
-class WeatherDetailViewModel @Inject constructor() : ViewModel() {
+class WeatherDetailViewModel @Inject constructor(
+    private val weatherRepository: WeatherRepository,
+    private val cityStorageRepository: CityStorageRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow<WeatherUiState>(WeatherUiState.Loading)
     val uiState: StateFlow<WeatherUiState> = _uiState
 
-    fun loadWeather() {
+    private val _cityName = MutableStateFlow<String?>(null)
+    val cityName: StateFlow<String?> = _cityName
+
+    fun loadWeather(cityId: Int) {
         viewModelScope.launch {
             _uiState.value = WeatherUiState.Loading
 
             try {
-                // 더미 데이터
-                val weather = WeatherDetail(
-                    temperature = 27,
-                    feelsLike = 25,
-                    description = "Sunny",
-                    iconCode = "01d",
-                    humidity = 60,
-                    windSpeed = 10,
-                    precipitationChance = 0.1f,
-                    visibility = 9800,
-                    cloudiness = 78,
-                    windDegree = 135,
-                    pressure = 1013,
-                    sunrise = 1726636384,
-                    sunset = 1726680975,
-                    rainAmount = 1.2,
-                    snowAmount = null
-                )
+                val city = cityStorageRepository.getCityById(cityId) ?: throw IllegalStateException("도시 정보 없음")
+                val isKorean = Locale.getDefault().language == "ko"
+                _cityName.value = when {
+                    isKorean -> city.nameKo
+                    else -> city.name
+                }
+                val weather = weatherRepository.getWeather(city.id, city.coord.lat, city.coord.lon)
+                val forecast = weatherRepository.getForecast(city.coord.lat, city.coord.lon)
 
-                val forecast = listOf(
-                    ForecastItem(time = "12:00", temperature = 27, iconCode = "01d"),
-                    ForecastItem(time = "15:00", temperature = 28, iconCode = "02d"),
-                    ForecastItem(time = "18:00", temperature = 26, iconCode = "03d"),
-                    ForecastItem(time = "21:00", temperature = 24, iconCode = "01n")
-                )
+                val weatherDetail = weather.toWeatherDetail()
+                val forecastList = forecast.toForecastList()
 
-                _uiState.value = WeatherUiState.Success(weather, forecast)
-            } catch (_: Exception) {
+                _uiState.value = WeatherUiState.Success(weatherDetail, forecastList)
+            } catch (e: Exception) {
                 _uiState.value = WeatherUiState.Error("날씨 데이터를 불러오는 데 실패했습니다.")
             }
         }
     }
+
+    fun ForecastResponse.toForecastList(): List<ForecastItem> {
+        return this.list?.take(8)?.mapNotNull { item ->
+            val temp = item.main?.temp?.toInt() ?: return@mapNotNull null
+            val icon = item.weather?.firstOrNull()?.icon.orEmpty()
+            val time = item.dt?.let {
+                val local = Instant.ofEpochSecond(it).atZone(ZoneId.systemDefault()).toLocalTime()
+                local.format(DateTimeFormatter.ofPattern("HH:mm"))
+            } ?: "??:??"
+
+            ForecastItem(
+                time = time,
+                temperature = temp,
+                iconCode = icon,
+            )
+        }.orEmpty()
+    }
+
+    fun WeatherResponse.toWeatherDetail(): WeatherDetail {
+        return WeatherDetail(
+            temperature = main?.temp?.toInt() ?: 0,
+            feelsLike = main?.feelsLike?.toInt() ?: 0,
+            description = weather?.firstOrNull()?.description.orEmpty(),
+            iconCode = weather?.firstOrNull()?.icon.orEmpty(),
+            humidity = main?.humidity ?: 0,
+            windSpeed = wind?.speed?.toInt() ?: 0,
+            precipitationChance = 0f,
+            visibility = visibility ?: 0,
+            cloudiness = clouds?.all ?: 0,
+            windDegree = wind?.deg ?: 0,
+            pressure = main?.pressure ?: 0,
+            sunrise = sys?.sunrise ?: 0,
+            sunset = sys?.sunset ?: 0,
+            rainAmount = rain?.oneHour ?: 0.0,
+            snowAmount = snow?.oneHour ?: 0.0,
+        )
+    }
+
 }

--- a/app/src/main/java/com/ben/simpleweather/features/main/WeatherListViewModel.kt
+++ b/app/src/main/java/com/ben/simpleweather/features/main/WeatherListViewModel.kt
@@ -1,33 +1,78 @@
 package com.ben.simpleweather.features.main
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ben.simpleweather.data.City
 import com.ben.simpleweather.data.WeatherItem
+import com.ben.simpleweather.data.repository.CityStorageRepository
+import com.ben.simpleweather.data.repository.WeatherRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
-@HiltViewModel
-class WeatherListViewModel @Inject constructor() : ViewModel() {
 
-    // 더미 데이터 (최대 10개 도시)
-    private val _weatherList = MutableStateFlow(
-        listOf(
-            WeatherItem("Seoul", 25, "Sunny"),
-            WeatherItem("Busan", 20, "Cloudy"),
-            WeatherItem("Incheon", 18, "Rainy"),
-            WeatherItem("Daegu", -5, "Snowy"),
-            WeatherItem("Gwangju", 15, "Windy")
-        )
-    )
+@HiltViewModel
+class WeatherListViewModel @Inject constructor(
+    private val cityStorageRepository: CityStorageRepository,
+    private val weatherRepository: WeatherRepository // Retrofit 통해 API 호출
+) : ViewModel() {
+
+    private val _weatherList = MutableStateFlow<List<WeatherItem>>(emptyList())
     val weatherList: StateFlow<List<WeatherItem>> = _weatherList.asStateFlow()
 
-    fun deleteSelected(selectedCities: List<String>) {
-        val updatedList = _weatherList.value.toMutableList()
-        updatedList.removeAll { it.cityName in selectedCities }
-        _weatherList.value = updatedList
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    init {
+        loadWeatherForSavedCities()
     }
+
+    fun loadWeatherForSavedCities() {
+        viewModelScope.launch {
+            _isLoading.value = true
+
+            val savedCities = cityStorageRepository.getSavedCities()
+
+            val weatherItems = savedCities.mapNotNull { city ->
+                try {
+                    val weather = weatherRepository.getWeather(
+                        cityId = city.id,
+                        latitude = city.coord.lat,
+                        longitude = city.coord.lon,
+                    )
+                    WeatherItem(
+                        city = city,
+                        cityName = city.displayName(),
+                        temperature = weather.main?.temp?.toInt() ?: 0,
+                        weatherType = weather.weather?.firstOrNull()?.description.orEmpty(),
+                        iconCode = weather.weather?.firstOrNull()?.icon.orEmpty()
+                    )
+                } catch (_: Exception) {
+                    null
+                }
+            }
+
+            _weatherList.value = weatherItems
+            _isLoading.value = false
+        }
+    }
+
+    fun deleteSelected(selectedCities: List<City>) {
+        viewModelScope.launch {
+            cityStorageRepository.removeCities(selectedCities)
+
+            val updatedList = _weatherList.value.toMutableList()
+            val namesToDelete = selectedCities.map { it.displayName() }
+
+            updatedList.removeAll { it.cityName in namesToDelete }
+            _weatherList.value = updatedList
+        }
+    }
+
 
     fun moveItem(fromIndex: Int, toIndex: Int) {
         val currentList = _weatherList.value.toMutableList()
@@ -37,6 +82,14 @@ class WeatherListViewModel @Inject constructor() : ViewModel() {
         val item = currentList.removeAt(fromIndex)
         currentList.add(toIndex, item)
         _weatherList.value = currentList
+    }
+
+    fun City.displayName(): String {
+        return if (Locale.getDefault().language == "ko") {
+            nameKo
+        } else {
+            name
+        }
     }
 
 }

--- a/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
+++ b/app/src/main/java/com/ben/simpleweather/network/WeatherApi.kt
@@ -12,7 +12,7 @@ interface WeatherApi {
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
         @Query("units") units: String = "metric",
-        @Query("lang") lang: String = "kr"
+        @Query("lang") lang: String = "en"
     ): WeatherResponse
 
     @GET("data/2.5/forecast")
@@ -20,7 +20,7 @@ interface WeatherApi {
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
         @Query("units") units: String = "metric",
-        @Query("lang") lang: String = "kr",
+        @Query("lang") lang: String = "en",
         @Query("cnt") count: Int? = null
     ): ForecastResponse
 }

--- a/app/src/test/java/com/ben/simpleweather/WeatherListViewModelTest.kt
+++ b/app/src/test/java/com/ben/simpleweather/WeatherListViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.ben.simpleweather
+
+import com.ben.simpleweather.data.City
+import com.ben.simpleweather.data.Coord
+import com.ben.simpleweather.data.remote.dto.MainDto
+import com.ben.simpleweather.data.remote.dto.WeatherDto
+import com.ben.simpleweather.data.remote.dto.WeatherResponse
+import com.ben.simpleweather.data.repository.CityStorageRepository
+import com.ben.simpleweather.data.repository.WeatherRepository
+import com.ben.simpleweather.features.main.WeatherListViewModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WeatherListViewModelTest {
+
+    private lateinit var viewModel: WeatherListViewModel
+
+    private val cityStorageRepo = mockk<CityStorageRepository>()
+    private val weatherRepo = mockk<WeatherRepository>()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val testCity = City(
+        id = 1001,
+        name = "Seoul",
+        nameKo = "서울",
+        state = "",
+        country = "KR",
+        coord = Coord(lat = 37.56, lon = 126.97)
+    )
+
+    private val weatherResponse = WeatherResponse(
+        coord = null,
+        weather = listOf(WeatherDto(800, "Clear", "맑음", "01d")),
+        main = MainDto(temp = 25.0),
+        wind = null, clouds = null, rain = null, snow = null,
+        dt = null, sys = null, timezone = null, id = null, name = null,
+        cod = null, visibility = null, base = null
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        coEvery { cityStorageRepo.getSavedCities() } returns listOf(testCity)
+        coEvery {
+            weatherRepo.getWeather(
+                cityId = testCity.id,
+                latitude = testCity.coord.lat,
+                longitude = testCity.coord.lon
+            )
+        } returns weatherResponse
+
+        viewModel = WeatherListViewModel(cityStorageRepo, weatherRepo)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `loadWeatherForSavedCities should populate weatherList`() = runTest {
+        viewModel.loadWeatherForSavedCities()
+        advanceUntilIdle()
+
+        val weatherList = viewModel.weatherList.value
+        assertEquals(1, weatherList.size)
+        val item = weatherList[0]
+        assertEquals("서울", item.cityName)
+        assertEquals(25, item.temperature)
+        assertEquals("맑음", item.weatherType)
+        assertEquals("01d", item.iconCode)
+    }
+
+    @Test
+    fun `deleteSelected should remove cities from list and storage`() = runTest {
+        // 초기 리스트 주입
+        viewModel.loadWeatherForSavedCities()
+        advanceUntilIdle()
+
+        coEvery { cityStorageRepo.removeCities(any()) } just runs
+
+        viewModel.deleteSelected(listOf(testCity))
+        advanceUntilIdle()
+
+        assertEquals(0, viewModel.weatherList.value.size)
+        coVerify { cityStorageRepo.removeCities(withArg { assertEquals(1, it.size) }) }
+    }
+
+    @Test
+    fun `moveItem should swap items correctly`() = runTest {
+        val city2 = testCity.copy(id = 2002, name = "Busan", nameKo = "부산", coord = Coord(35.17, 129.07))
+        val cityList = listOf(testCity, city2)
+
+        coEvery { cityStorageRepo.getSavedCities() } returns cityList
+        coEvery {
+            weatherRepo.getWeather(any(), any(), any())
+        } returns weatherResponse
+
+        viewModel.loadWeatherForSavedCities()
+        advanceUntilIdle()
+
+        viewModel.moveItem(0, 1)
+
+        val reordered = viewModel.weatherList.value
+        assertEquals("부산", reordered[0].cityName)
+        assertEquals("서울", reordered[1].cityName)
+    }
+}


### PR DESCRIPTION
## 이 풀 리퀘스트는 날씨 앱의 구조를 대대적으로 리팩토링하고 기능을 업그레이드합니다

새로운 Repository 레이어를 도입하여 날씨 데이터를 처리하고, 도시 관리 기능을 개선하며, 날씨 리스트 및 상세 UI의 데이터 흐름을 간결하게 리팩토링했습니다. 또한 날씨 데이터를 캐싱하고, 상세 화면 네비게이션에 city name 대신 city ID를 사용하도록 변경하였습니다.

---

### 📦 Repository 및 데이터 레이어 개선

- `WeatherRepository`와 그 구현체 `WeatherRepositoryImpl`을 새로 추가하여 날씨 및 예보 데이터를 가져오고 캐싱하는 역할을 수행합니다.
  - DI 바인딩도 함께 설정했습니다.
  - [[1]](diffhunk://#diff-c3af8462166bb6179671e0ac66258ea7bbc1aa15f7acc0216d468a3676e7e822R1-R17)
  - [[2]](diffhunk://#diff-236b9292642fd5b6ce1608dbecba6bcecb5233764463cb2d0decca55be67d0e2R1-R38)

- `CachedWeather` 데이터 클래스를 추가하여 캐싱 구조를 정의했습니다.

- `CityStorageRepository`에 다음 기능 추가:
  - 여러 도시 제거
  - city ID로 도시 조회
  - 구현체에 해당 기능 반영 완료
  - [[1]](diffhunk://#diff-796048adac0a1ddd3d1f753e46ddd52005d4f9cd3a94749c7e3ec955d9e33aaaR8-R9)

---

### 🧭 네비게이션 및 데이터 전달 구조 개선

- 날씨 상세 화면으로 이동 시 `city name` 문자열이 아닌 `city ID`를 사용하도록 네비게이션 구조를 전면 수정했습니다.
  - route, arguments, 데이터 전달 로직을 일괄 수정함
  - [[1]](diffhunk://#diff-b31adea8d31ad71d80c5cfeb5098e43b0d0de9fad74fb6de5b213007b8367f3bR4-R8)

---

### 💡 UI 및 ViewModel 업데이트

- `WeatherDetailViewModel`에서 새로운 Repository를 사용하도록 리팩토링하고, DTO → UI 모델 매핑 및 도시명 로컬라이징 처리 로직을 추가했습니다.

- `WeatherListScreen`에서 다음 사항을 개선:
  - 새 구조에 맞게 city, weather 데이터를 반영
  - 삭제 모드 처리 로직 개선
  - 로딩 인디케이터 추가
  - [[1]](diffhunk://#diff-fc1cffa4c05b85c515ae3bca6290bd045f662589b5a532bb64a2e1b88dddd6c6L75-R119)

- `WeatherItem` 데이터 클래스에 `City` 객체와 아이콘 코드 필드 추가

---

### 🧹 코드 정리 및 유틸리티 분리

- `WeatherIcon` 컴포저블을 재사용 가능하도록 별도 유틸리티 파일로 분리
  - [[1]](diffhunk://#diff-c9ad42584e4c53d0f7d0bd4cd5587594d262589ae08cc1f6a1028acf2a69b574R1-R19)

- 여러 파일에서 불필요한 import 및 코드 정리 수행
  - [[1]](diffhunk://#diff-fc1cffa4c05b85c515ae3bca6290bd045f662589b5a532bb64a2e1b88dddd6c6L5-R48)
  
  closes #10 